### PR TITLE
Update AppCatalog description for KBASE-4741

### DIFF
--- a/ui/narrative/methods/build_genome_set_from_tree/display.yaml
+++ b/ui/narrative/methods/build_genome_set_from_tree/display.yaml
@@ -54,6 +54,8 @@ parameters :
 
 description : |
     <p>This method allows a user to extract a set of genomes from a user-generated species Tree object. First, this method copies the set of genomes from the tree to the current narrative.  The output widget allows to name the Genome Set object as well as to select specific genomes from the genomes contained in the input Tree object. The genomes can be deleted from the output set by clicking the trash can icon.  Additional genomes can be added by pressing &quot;Add&quot; button at the bottom of the table in the Narrative panel. Finally, the Genome Set object is saved when the &quot;Save&quot; button is clicked. The resulting Genome Set object can then be submitted to additional methods such as <a data-method-id=Òcompute_pangenomeÓ>Compute Pangenome</a> and <a data-method-id=Òinsert_genomeset_into_species_tree_genericÓ>Insert Set of Genomes into Species Tree</a>.</p>
-    
+   
+<p>Note: when inserting one or more genomes into a species tree, the inserted genomes that are also contained within the KBase list of species will be duplicated in the tree. One copy will have the KBase list ID and the other will have the ID of the inserted genome. The genomes will also be duplicated in any genome set generated from the tree.</p>
+ 
     <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, <a href="mailto:help@kbase.us">e-mail help@kbase.us</a></p>
 

--- a/ui/narrative/methods/build_genome_set_from_tree/display.yaml
+++ b/ui/narrative/methods/build_genome_set_from_tree/display.yaml
@@ -57,5 +57,5 @@ description : |
    
 <p>Note: when inserting one or more genomes into a species tree, the inserted genomes that are also contained within the KBase list of species will be duplicated in the tree. One copy will have the KBase list ID and the other will have the ID of the inserted genome. The genomes will also be duplicated in any genome set generated from the tree.</p>
  
-    <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, <a href="mailto:help@kbase.us">e-mail help@kbase.us</a></p>
+    <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, contact us at <a href="http://kbase.us/contact-us/">http://kbase.us/contact-us/</a></p>
 

--- a/ui/narrative/methods/build_genome_set_from_tree/spec.json
+++ b/ui/narrative/methods/build_genome_set_from_tree/spec.json
@@ -1,9 +1,9 @@
 {
   "ver" : "1.0.0",
-  "authors" : [ ],
-  "contact" : "help@kbase.us",
+  "authors" : [ "rsutormin"  ],
+  "contact" : "kbase.us/contact-us",
   "visble" : true,
-  "categories" : ["active"],
+  "categories" : ["active","comparative_genomics"],
   "widgets" : {
     "input" : null,
     "output" : "kbaseGenomeSetBuilder"

--- a/ui/narrative/methods/insert_genomeset_into_species_tree/display.yaml
+++ b/ui/narrative/methods/insert_genomeset_into_species_tree/display.yaml
@@ -69,7 +69,7 @@ description : |
 
 <p>Note: when inserting one or more genomes into a species tree, the inserted genomes that are also contained within the KBase list of species will be duplicated in the tree. One copy will have the KBase list ID and the other will have the ID of the inserted genome. The genomes will also be duplicated in any genome set generated from the tree.</p>
     
-    <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, <a href="mailto:help@kbase.us">e-mail help@kbase.us</a></p>
+    <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, contact us at <a href="http://kbase.us/contact-us/">http://kbase.us/contact-us/</a></p>
 
 publications :
     -

--- a/ui/narrative/methods/insert_genomeset_into_species_tree/display.yaml
+++ b/ui/narrative/methods/insert_genomeset_into_species_tree/display.yaml
@@ -66,6 +66,8 @@ parameters :
 
 description : |
     <p>This method allows a user to construct a phylogenetic tree combining the GenomeSet provided by the user with a set of closely related genomes from the KBase list of species. Since the number of genomes available in KBase is very large, the procedure starts by selecting a subset of KBase genomes closely related to the user-provided genome. Relatedness is determined by alignment similarity to a select subset of COG (Clusters of Orthologous Groups) domains. Next, a phylogenetic tree is reconstructed using FastTree (a method to quickly estimate maximum likelihood phylogeny, see Publications) with the genome provided by the user and the set of genomes identified as similar in the previous step. The output tree can be shown with two possible layouts - rectangular and circular.</p>
+
+<p>Note: when inserting one or more genomes into a species tree, the inserted genomes that are also contained within the KBase list of species will be duplicated in the tree. One copy will have the KBase list ID and the other will have the ID of the inserted genome. The genomes will also be duplicated in any genome set generated from the tree.</p>
     
     <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, <a href="mailto:help@kbase.us">e-mail help@kbase.us</a></p>
 

--- a/ui/narrative/methods/insert_genomeset_into_species_tree/spec.json
+++ b/ui/narrative/methods/insert_genomeset_into_species_tree/spec.json
@@ -1,9 +1,9 @@
 {
   "ver" : "1.0.1",
-  "authors" : [ ],
-  "contact" : "help@kbase.us",
+  "authors" : [ "rsutormin"  ],
+  "contact" : "kbase.us/contact-us",
   "visble" : true,
-  "categories" : ["active"],
+  "categories" : ["active","comparative_genomics"],
   "widgets" : {
     "input" : null,
     "output" : "kbaseTree"

--- a/ui/narrative/methods/insert_set_of_genomes_into_species_tree/display.yaml
+++ b/ui/narrative/methods/insert_set_of_genomes_into_species_tree/display.yaml
@@ -62,7 +62,7 @@ description : |
 
 <p>Note: when inserting one or more genomes into a species tree, the inserted genomes that are also contained within the KBase list of species will be duplicated in the tree. One copy will have the KBase list ID and the other will have the ID of the inserted genome. The genomes will also be duplicated in any genome set generated from the tree.</p>
     
-    <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, <a href="mailto:help@kbase.us">e-mail help@kbase.us</a></p>
+    <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, contact us at <a href="http://kbase.us/contact-us/">http://kbase.us/contact-us/</a></p>
     
 publications :
     -

--- a/ui/narrative/methods/insert_set_of_genomes_into_species_tree/display.yaml
+++ b/ui/narrative/methods/insert_set_of_genomes_into_species_tree/display.yaml
@@ -59,6 +59,8 @@ parameters :
 
 description : |
     <p>This method allows a user to construct a phylogenetic tree combining the genome(s) provided by the user with a set of closely related genomes selected from all public KBase genomes. Since the number of genomes available in KBase is very large, the procedure starts by selecting a subset of public KBase genomes closely related to the user-provided genomes. Relatedness is determined by alignment similarity to a select subset of COG (Clusters of Orthologous Groups) domains. Next, a phylogenetic tree is reconstructed using FastTree (a method to quickly estimate maximum likelihood phylogeny, see Publications) with the genome provided by the user and the set of genomes identified as similar in the previous step.</p>
+
+<p>Note: when inserting one or more genomes into a species tree, the inserted genomes that are also contained within the KBase list of species will be duplicated in the tree. One copy will have the KBase list ID and the other will have the ID of the inserted genome. The genomes will also be duplicated in any genome set generated from the tree.</p>
     
     <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Roman Sutormin. For questions, <a href="mailto:help@kbase.us">e-mail help@kbase.us</a></p>
     

--- a/ui/narrative/methods/insert_set_of_genomes_into_species_tree/spec.json
+++ b/ui/narrative/methods/insert_set_of_genomes_into_species_tree/spec.json
@@ -1,9 +1,9 @@
 {
   "ver" : "1.0.0",
-  "authors" : [ ],
-  "contact" : "help@kbase.us",
+  "authors" : [ "rsutormin" ],
+  "contact" : "kbase.us/contact-us",
   "visble" : true,
-  "categories" : ["active"],
+  "categories" : ["active","comparative_genomics"],
   "widgets" : {
     "input" : null,
     "output" : "kbaseTree"


### PR DESCRIPTION
Adding a note to the app descriptions that explains why the user might have duplicate genomes in the tree and in the genome set.