### PR TITLE
Fix TLS 1.2 issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,22 @@ MAINTAINER KBase Developer
 # Insert apt-get instructions here to install
 # any required dependencies for your module.
 
+# update java
+RUN add-apt-repository ppa:openjdk-r/ppa \
+	&& sudo apt-get update \
+	&& sudo apt-get -y install openjdk-8-jdk \
+	&& echo java versions: \
+	&& java -version \
+	&& javac -version \
+	&& echo $JAVA_HOME \
+	&& ls -l /usr/lib/jvm \
+	&& cd /kb/runtime \
+	&& rm java \
+	&& ln -s /usr/lib/jvm/java-8-openjdk-amd64 java \
+	&& ls -l
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+
 # update jars
 RUN cd /kb/dev_container/modules/jars \
 	&& git pull \
@@ -23,13 +39,6 @@ RUN mkdir -p /kb/module/work
 RUN chmod 777 /kb/module
 
 WORKDIR /kb/module
-
-# Fix for problem with lets-encript in Java (PKIX path building failed:
-#   sun.security.provider.certpath.SunCertPathBuilderException: unable
-#   to find valid certification path to requested target)
-RUN keytool -import -keystore /usr/lib/jvm/java-7-oracle/jre/lib/security/cacerts \
-    -storepass changeit -noprompt -trustcacerts -alias letsencryptauthorityx3 \
-    -file ./ssl/lets-encrypt-x3-cross-signed.der
 
 RUN mkdir -p bin
 RUN cp /kb/deps/bin/* ./bin/


### PR DESCRIPTION
Without fix, kb-sdk test fails in appdev with

```
test:
    [junit] Running speciestreebuilder.test.SpeciesTreeBuilderServerTest
    [junit] Testsuite:
speciestreebuilder.test.SpeciesTreeBuilderServerTest
    [junit] Tests run: 0, Failures: 0, Errors: 1, Skipped: 0, Time
elapsed: 0.231 sec
    [junit] Tests run: 0, Failures: 0, Errors: 1, Skipped: 0, Time
elapsed: 0.231 sec
    [junit]
    [junit] Testcase:
speciestreebuilder.test.SpeciesTreeBuilderServerTest took 0 sec
    [junit] 	Caused an ERROR
    [junit] Connection reset
    [junit] java.net.SocketException: Connection reset
    [junit] 	at
java.net.SocketInputStream.read(SocketInputStream.java:196)
    [junit] 	at
java.net.SocketInputStream.read(SocketInputStream.java:122)
    [junit] 	at
sun.security.ssl.InputRecord.readFully(InputRecord.java:442)
    [junit] 	at sun.security.ssl.InputRecord.read(InputRecord.java:480)
    [junit] 	at
sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:934)
    [junit] 	at
sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1332)
    [junit] 	at
sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1359)
    [junit] 	at
sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1343)
    [junit] 	at
sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:559)
    [junit] 	at
sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:185)
    [junit] 	at
sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1301)
    [junit] 	at
java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:468)
    [junit] 	at
sun.net.www.protocol.https.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java:338)
    [junit] 	at
us.kbase.auth.AuthService.checkServiceUrl(AuthService.java:492)
    [junit] 	at
us.kbase.auth.ConfigurableAuthService.<init>(ConfigurableAuthService.java:46)
    [junit] 	at
speciestreebuilder.test.SpeciesTreeBuilderServerTest.init(SpeciesTreeBuilderServerTest.java:59)
    [junit]
```

With the fix, passes in appdev.

lets encrypt hack no longer needed with Java 8.