### PR TITLE
PTV-1900: allow existing or new genomeset refs to be used as input

### DIFF
--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1695167676101</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### Version 0.1.4
+- Convert `ref` to `putative-ref` in the specs to allow the app to use existing objects or create new ones.
+
 ### Version 0.1.3
 - Add object url into error message
 

--- a/SpeciesTreeBuilder.spec
+++ b/SpeciesTreeBuilder.spec
@@ -4,26 +4,26 @@ A KBase module: SpeciesTreeBuilder
 
 module SpeciesTreeBuilder {
 
-    /* 
+    /*
         A workspace ID that references a Tree data object.
         @id ws KBaseTrees.Tree
     */
     typedef string ws_tree_id;
-        
-    /* 
+
+    /*
         A workspace ID that references a Genome data object.
         @id ws KBaseGenomes.Genome KBaseGenomeAnnotations.GenomeAnnotation
     */
     typedef string ws_genome_id;
-    
-    /* 
+
+    /*
         A workspace ID that references a GenomeSet data object.
         @id ws KBaseSearch.GenomeSet
     */
     typedef string ws_genomeset_id;
 
 
-    /* 
+    /*
         Input data type for construct_species_tree method. Method produces object of Tree type.
 
         new_genomes - (optional) the list of genome references to use in constructing a tree; either
@@ -32,9 +32,9 @@ module SpeciesTreeBuilder {
             field should be defined.
         out_workspace - (required) the workspace to deposit the completed tree
         out_tree_id - (optional) the name of the newly constructed tree (will be random if not present or null)
-	out_genomeset_ref - the name of the output genomeset object
-	copy_genomes - 1 means copy genomes to user workspace; 0 means refer only to the public genomes
-        use_ribosomal_s9_only - (optional) 1 means only one protein family (Ribosomal S9) is used for 
+	    out_genomeset_ref - the name of the output genomeset object
+	    copy_genomes - 1 means copy genomes to user workspace; 0 means refer only to the public genomes
+        use_ribosomal_s9_only - (optional) 1 means only one protein family (Ribosomal S9) is used for
             tree construction rather than all 49 improtant families, default value is 0.
         nearest_genome_count - (optional) defines maximum number of public genomes nearest to
             requested genomes that will show in output tree.
@@ -45,19 +45,19 @@ module SpeciesTreeBuilder {
         string out_workspace;
         string out_tree_id;
         ws_genomeset_id out_genomeset_ref;
-	int copy_genomes;
+    	int copy_genomes;
         int use_ribosomal_s9_only;
         int nearest_genome_count;
     } ConstructSpeciesTreeParams;
 
     /*
         Output is a report, and a Tree object
-        */
-        typedef structure {
-    	ws_tree_id output_result_id;
-    	string report_name;
-    	string report_ref;
-        } ConstructSpeciesTreeOutput;
+    */
+    typedef structure {
+        ws_tree_id output_result_id;
+        string report_name;
+        string report_ref;
+    } ConstructSpeciesTreeOutput;
 
     /*
         Build a species tree out of a set of given genome references.
@@ -65,11 +65,11 @@ module SpeciesTreeBuilder {
     funcdef construct_species_tree(ConstructSpeciesTreeParams input) returns (ConstructSpeciesTreeOutput out) authentication required;
 
 
-    /* 
+    /*
         Input data type for find_close_genomes method. Method produces list of refereces to public genomes similar to query.
 
         query_genome - (required) query genome reference
-        max_mismatch_percent - (optional) defines maximum mismatch percentage when compare aminoacids from user genome with 
+        max_mismatch_percent - (optional) defines maximum mismatch percentage when compare aminoacids from user genome with
             public genomes (defualt value is 5).
     */
     typedef structure {
@@ -78,12 +78,12 @@ module SpeciesTreeBuilder {
     } FindCloseGenomesParams;
 
     /*
-        Find closely related public genomes based on COG of ribosomal s9 subunits. 
+        Find closely related public genomes based on COG of ribosomal s9 subunits.
     */
     funcdef find_close_genomes(FindCloseGenomesParams params) returns (list<ws_genome_id>) authentication required;
 
 
-    /* 
+    /*
         Input data type for guess_taxonomy_path method. Method produces taxonomy path string.
 
         query_genome - (required) query genome reference
@@ -91,17 +91,17 @@ module SpeciesTreeBuilder {
     typedef structure {
         ws_genome_id query_genome;
     } GuessTaxonomyPathParams;
-	
+
     /*
-        Search for taxonomy path from closely related public genomes (approach similar to find_close_genomes). 
+        Search for taxonomy path from closely related public genomes (approach similar to find_close_genomes).
     */
     funcdef guess_taxonomy_path(GuessTaxonomyPathParams params) returns (string) authentication required;
 
-		
+
     typedef structure {
         ws_tree_id tree_ref;
         ws_genomeset_id genomeset_ref;
     } BuildGenomeSetFromTreeParams;
-	
+
     funcdef build_genome_set_from_tree(BuildGenomeSetFromTreeParams params) returns (ws_genomeset_id genomeset_ref) authentication required;
 };

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,10 +8,10 @@ service-language:
     java
 
 module-version:
-    0.1.3
+    0.1.4
 
 owners:
-    [dakota, gaprice, jmc, ziming_yang_1]
+    [dakota, gaprice, jmc, ziming_yang_1, ialarmedalien]
 
 data-version:
     1.2

--- a/lib/src/speciestreebuilder/GenomeSetBuilder.java
+++ b/lib/src/speciestreebuilder/GenomeSetBuilder.java
@@ -27,103 +27,106 @@ import workspace.ObjectSpecification;
 import workspace.WorkspaceClient;
 
 public class GenomeSetBuilder {
-    public static String buildGenomeSetFromTree(Map<String, String> config, AuthToken token, 
-                                                String treeRef, String genomeSetRef, boolean copyGenomes) throws Exception {
-        return buildGenomeSetFromTree(config.get("workspace-url"), token, treeRef, genomeSetRef, copyGenomes);
-    }
-    
-    public static String buildGenomeSetFromTree(String wsUrl, AuthToken token, String treeRef, 
-                                                String genomeSetRef, boolean copyGenomes) throws Exception {
-        URL callbackUrl = new URL(System.getenv("SDK_CALLBACK_URL"));
-        DataFileUtilClient dfu = new DataFileUtilClient(callbackUrl, token);
-        dfu.setIsInsecureHttpConnectionAllowed(true);
+	public static String buildGenomeSetFromTree(Map<String, String> config, AuthToken token,
+			String treeRef, String genomeSetRef, boolean copyGenomes) throws Exception {
+		return buildGenomeSetFromTree(config.get("workspace-url"), token, treeRef, genomeSetRef, copyGenomes);
+	}
 
-        WorkspaceClient ws = new WorkspaceClient(new URL(wsUrl), token);
+	public static String buildGenomeSetFromTree(String wsUrl, AuthToken token, String treeRef,
+			String genomeSetRef, boolean copyGenomes) throws Exception {
+		URL callbackUrl = new URL(System.getenv("SDK_CALLBACK_URL"));
+		DataFileUtilClient dfu = new DataFileUtilClient(callbackUrl, token);
+		dfu.setIsInsecureHttpConnectionAllowed(true);
+
+		WorkspaceClient ws = new WorkspaceClient(new URL(wsUrl), token);
 		ws.setIsInsecureHttpConnectionAllowed(true);
 		ObjectData data = dfu.getObjects(new GetObjectsParams().withObjectRefs(Arrays.asList(
-		        treeRef))).getData().get(0);
+				treeRef))).getData().get(0);
 		Tree tree = data.getData().asClassInstance(Tree.class);
 		Map<String, Map<String, List<String>>> refs = tree.getWsRefs();
 		String[] wsGenomeSetName = genomeSetRef.split("/");
 		String workspace = wsGenomeSetName[0];
-        Long wsId = dfu.wsNameToId(workspace);
+		Long wsId = dfu.wsNameToId(workspace);
 		String genomeSetName = wsGenomeSetName[1];
 		Map<String, Object> genomeSetData = new TreeMap<String, Object>();
 		genomeSetData.put("description", "GenomeSet of genome included in species tree " + treeRef);
 		Map<String, Map<String, String>> elements = new TreeMap<String, Map<String, String>>();
 		genomeSetData.put("elements", elements);
-	    int gcount = 0;
-	    List<String> genomesToCopy = new ArrayList<String>();
+		int gcount = 0;
+		List<String> genomesToCopy = new ArrayList<String>();
 		for (String key : refs.keySet()) {
-		    if (refs.get(key).containsKey("g") && refs.get(key).get("g").size() > 0) {
-		        String ref = refs.get(key).get("g").get(0);
-		        long refWsId = Long.parseLong(ref.split("/")[0]);
-		        if ((wsId.equals(refWsId)) || (!copyGenomes)) {
-		            String param = "param" + gcount;
-		            gcount++;
-		            Map<String, String> element = new TreeMap<String, String>();
-		            element.put("ref", ref);
-		            elements.put(param, element);
-		            //System.out.println("Genome " + key + " (ref=" + ref + ") wasn't copied to " + workspace);
-		        } else {
-		            genomesToCopy.add(key);
-		        }
+			if (refs.get(key).containsKey("g") && refs.get(key).get("g").size() > 0) {
+				String ref = refs.get(key).get("g").get(0);
+				long refWsId = Long.parseLong(ref.split("/")[0]);
+				if ((wsId.equals(refWsId)) || (!copyGenomes)) {
+					String param = "param" + gcount;
+					gcount++;
+					Map<String, String> element = new TreeMap<String, String>();
+					element.put("ref", ref);
+					elements.put(param, element);
+					// System.out.println("Genome " + key + " (ref=" + ref + ") wasn't copied to " +
+					// workspace);
+				} else {
+					genomesToCopy.add(key);
+				}
 			} else {
-			    System.err.println("[WARNING] GenomeSetBuilder: Can't find genome object " +
-			    		"reference for id: " + key);
+				System.err.println("[WARNING] GenomeSetBuilder: Can't find genome object " +
+						"reference for id: " + key);
 			}
 		}
 		if (genomesToCopy.size() > 0) {
-		    List<ObjectSpecification> objectids = new ArrayList<ObjectSpecification>();
-		    for (String key : genomesToCopy) {
-                String ref = refs.get(key).get("g").get(0);
-		        objectids.add(new ObjectSpecification().withRef(ref));
-		    }
-		    Set<String> namehash = new TreeSet<String>();
-		    List<Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String,String>>> infos = 
-		            ws.getObjectInfoNew(new GetObjectInfoNewParams().withObjects(objectids).withIncludeMetadata(0L));
-		    for (Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String,String>> item : infos) {
-		        namehash.add(item.getE2());
-		    }
-		    for (String key : genomesToCopy) {
-		        String origRef = refs.get(key).get("g").get(0);
-		        String newname = tree.getDefaultNodeLabels().get(key);
-		        newname = cleanName(newname);
-		        if (namehash.contains(newname)) {
-		            int count = 0;
-		            String testname = newname + "_" + count;
-		            while (namehash.contains(testname)) {
-		                count++;
-		                testname = newname + "_" + count;
-		            }
-		            newname = testname;
-		        }
-		        namehash.add(newname);
-		        Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String,String>> wsinfo = 
-		        		ws.copyObject(new CopyObjectParams().withTo(new ObjectIdentity().withWorkspace(workspace)
-		        		.withName(newname)).withFrom(new ObjectIdentity().withRef(origRef)));
-		        //System.out.println("Genome " + key + " (ref=" + origRef + ") was copied to " + workspace + "/" + newname);
-		        String ref = WorkspaceUtil.getRefFromObjectInfo(wsinfo);
-		        String param = "param" + gcount;
-		        gcount++;
-		        Map<String, String> element = new TreeMap<String, String>();
-		        element.put("ref", ref);
-		        elements.put(param, element);
-		    }
+			List<ObjectSpecification> objectids = new ArrayList<ObjectSpecification>();
+			for (String key : genomesToCopy) {
+				String ref = refs.get(key).get("g").get(0);
+				objectids.add(new ObjectSpecification().withRef(ref));
+			}
+			Set<String> namehash = new TreeSet<String>();
+			List<Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>>> infos = ws
+					.getObjectInfoNew(new GetObjectInfoNewParams().withObjects(objectids).withIncludeMetadata(0L));
+			for (Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> item : infos) {
+				namehash.add(item.getE2());
+			}
+			for (String key : genomesToCopy) {
+				String origRef = refs.get(key).get("g").get(0);
+				String newname = tree.getDefaultNodeLabels().get(key);
+				newname = cleanName(newname);
+				if (namehash.contains(newname)) {
+					int count = 0;
+					String testname = newname + "_" + count;
+					while (namehash.contains(testname)) {
+						count++;
+						testname = newname + "_" + count;
+					}
+					newname = testname;
+				}
+				namehash.add(newname);
+				Tuple11<Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> wsinfo = ws
+						.copyObject(new CopyObjectParams().withTo(new ObjectIdentity().withWorkspace(workspace)
+								.withName(newname)).withFrom(new ObjectIdentity().withRef(origRef)));
+				// System.out.println("Genome " + key + " (ref=" + origRef + ") was copied to "
+				// + workspace + "/" + newname);
+				String ref = WorkspaceUtil.getRefFromObjectInfo(wsinfo);
+				String param = "param" + gcount;
+				gcount++;
+				Map<String, String> element = new TreeMap<String, String>();
+				element.put("ref", ref);
+				elements.put(param, element);
+			}
 		}
 		return WorkspaceUtil.getRefFromObjectInfo(dfu.saveObjects(new SaveObjectsParams().withId(wsId)
-		        .withObjects(Arrays.asList(new ObjectSaveData().withType("KBaseSearch.GenomeSet")
-		                .withName(genomeSetName).withData(new UObject(genomeSetData))))).get(0));
-    }
+				.withObjects(Arrays.asList(new ObjectSaveData().withType("KBaseSearch.GenomeSet")
+						.withName(genomeSetName).withData(new UObject(genomeSetData)))))
+				.get(0));
+	}
 
-    protected static String cleanName(String text) {
-        StringBuilder ret = new StringBuilder();
-        for (int pos = 0; pos < text.length(); pos++) {
-            char ch = text.charAt(pos);
-            if ((!Character.isAlphabetic(ch)) && (!Character.isDigit(ch)) && (ch != '_') && (ch != '.'))
-                ch = '_';
-            ret.append(ch);
-        }
-        return ret.toString();
-    }
+	protected static String cleanName(String text) {
+		StringBuilder ret = new StringBuilder();
+		for (int pos = 0; pos < text.length(); pos++) {
+			char ch = text.charAt(pos);
+			if ((!Character.isAlphabetic(ch)) && (!Character.isDigit(ch)) && (ch != '_') && (ch != '.'))
+				ch = '_';
+			ret.append(ch);
+		}
+		return ret.toString();
+	}
 }

--- a/ui/narrative/methods/build_genome_set_from_tree/display.yaml
+++ b/ui/narrative/methods/build_genome_set_from_tree/display.yaml
@@ -41,7 +41,7 @@ parameters :
         ui-name : |
             Output GenomeSet
         short-hint : |
-            The output collection of Genome objects.
+            The output collection of Genome objects. Note that using an existing genome set will replace the contents of that set with the output of this app.
         placeholder: |
             Name the set of genomes generated
 

--- a/ui/narrative/methods/build_genome_set_from_tree/spec.json
+++ b/ui/narrative/methods/build_genome_set_from_tree/spec.json
@@ -1,41 +1,56 @@
 {
-  "ver" : "1.0.0",
-  "authors" : [ "rsutormin" ],
-  "contact" : "http://kbase.us/contact-us/",
-  "visble" : false,
-  "categories" : ["comparative_genomics"],
-  "widgets" : {
-    "input" : null,
-    "output" : "kbaseGenomeSetBuilder"
+  "ver": "1.0.0",
+  "authors": [
+    "rsutormin"
+  ],
+  "contact": "http://kbase.us/contact-us/",
+  "visble": false,
+  "categories": [
+    "comparative_genomics"
+  ],
+  "widgets": {
+    "input": null,
+    "output": "kbaseGenomeSetBuilder"
   },
-  "parameters" : [ {
-    "id" : "param0",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseTrees.Tree" ]
+  "parameters": [
+    {
+      "id": "param0",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseTrees.Tree"
+        ]
+      }
+    },
+    {
+      "id": "genomeSetName",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseSearch.GenomeSet"
+        ],
+        "is_output_name": true
+      }
     }
-  }, {
-    "id" : "genomeSetName",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseSearch.GenomeSet" ],
-      "is_output_name":true
-    }
-  } ],
-  "behavior" : {
-    "service-mapping" : {
-      "url" : "",
-      "name" : "SpeciesTreeBuilder",
-      "method" : "build_genome_set_from_tree",
-      "input_mapping" : [
+  ],
+  "behavior": {
+    "service-mapping": {
+      "url": "",
+      "name": "SpeciesTreeBuilder",
+      "method": "build_genome_set_from_tree",
+      "input_mapping": [
         {
           "input_parameter": "param0",
           "target_property": "tree_ref",
@@ -47,10 +62,10 @@
             "prefix": "genomeset_"
           },
           "target_property": "genomeset_ref",
-          "target_type_transform": "ref"
+          "target_type_transform": "putative-ref"
         }
       ],
-      "output_mapping" : [
+      "output_mapping": [
         {
           "input_parameter": "genomeSetName",
           "target_property": "genomeSetName"

--- a/ui/narrative/methods/insert_genomeset_into_species_tree/display.yaml
+++ b/ui/narrative/methods/insert_genomeset_into_species_tree/display.yaml
@@ -62,7 +62,7 @@ parameters :
         ui-name : |
             Output GenomeSet
         short-hint : |
-            A collection of Genome objects.
+            A collection of Genome objects. Note that using an existing genome set will replace the contents of that set with the output of this app.
         placeholder: |
             Name the set of genomes generated
 

--- a/ui/narrative/methods/insert_genomeset_into_species_tree/spec.json
+++ b/ui/narrative/methods/insert_genomeset_into_species_tree/spec.json
@@ -1,78 +1,103 @@
 {
-  "ver" : "1.0.2",
-  "authors" : [ "rsutormin" ],
-  "contact" : "http://kbase.us/contact-us/",
-  "visble" : true,
-  "categories" : ["active","comparative_genomics"],
-  "widgets" : {
-    "input" : null,
-    "output" : "no-display"
+  "ver": "1.0.2",
+  "authors": [
+    "rsutormin"
+  ],
+  "contact": "http://kbase.us/contact-us/",
+  "visble": true,
+  "categories": [
+    "active",
+    "comparative_genomics"
+  ],
+  "widgets": {
+    "input": null,
+    "output": "no-display"
   },
-  "parameters" : [ {
-    "id" : "param0",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseSearch.GenomeSet" ]
-    }
-  }, {
-    "id" : "param1",
-    "optional" : true,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "20" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ ],
-      "validate_as": "int",
-      "min_int" : 1,
-      "max_int" : 200
-    }
-  }, {
-    "id": "copy_genomes",
-    "optional": false,
-    "advanced": false,
-    "allow_multiple": false,
-    "default_values": [
+  "parameters": [
+    {
+      "id": "param0",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseSearch.GenomeSet"
+        ]
+      }
+    },
+    {
+      "id": "param1",
+      "optional": true,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        "20"
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [],
+        "validate_as": "int",
+        "min_int": 1,
+        "max_int": 200
+      }
+    },
+    {
+      "id": "copy_genomes",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
         "0"
-    ],
-    "field_type": "checkbox",
-    "checkbox_options": {
+      ],
+      "field_type": "checkbox",
+      "checkbox_options": {
         "checked_value": 1,
         "unchecked_value": 0
+      }
+    },
+    {
+      "id": "treeID",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseTrees.Tree"
+        ],
+        "is_output_name": true
+      }
+    },
+    {
+      "id": "genomeSetName",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseSearch.GenomeSet"
+        ],
+        "is_output_name": true
+      }
     }
-  }, {
-    "id" : "treeID",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseTrees.Tree" ],
-      "is_output_name":true
-    }
-  }, {
-    "id" : "genomeSetName",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseSearch.GenomeSet" ],
-      "is_output_name":true
-    }
-  } ],
-  "behavior" : {
-    "service-mapping" : {
-      "url" : "",
-      "name" : "SpeciesTreeBuilder",
-      "method" : "construct_species_tree",
-      "input_mapping" : [
+  ],
+  "behavior": {
+    "service-mapping": {
+      "url": "",
+      "name": "SpeciesTreeBuilder",
+      "method": "construct_species_tree",
+      "input_mapping": [
         {
           "input_parameter": "param0",
           "target_property": "genomeset_ref",
@@ -94,7 +119,7 @@
         {
           "input_parameter": "genomeSetName",
           "target_property": "out_genomeset_ref",
-          "target_type_transform": "ref"
+          "target_type_transform": "putative-ref"
         },
         {
           "narrative_system_variable": "workspace",
@@ -105,18 +130,30 @@
           "target_property": "use_ribosomal_s9_only"
         }
       ],
-      "output_mapping" : [
+      "output_mapping": [
         {
-          "service_method_output_path": [0, "output_result_id"],
+          "service_method_output_path": [
+            0,
+            "output_result_id"
+          ],
           "target_property": "output_result_id"
-        }, {
+        },
+        {
           "narrative_system_variable": "workspace",
           "target_property": "workspaceID"
-        }, {
-          "service_method_output_path": [0, "report_name"],
+        },
+        {
+          "service_method_output_path": [
+            0,
+            "report_name"
+          ],
           "target_property": "report_name"
-        }, {
-          "service_method_output_path": [0, "report_ref"],
+        },
+        {
+          "service_method_output_path": [
+            0,
+            "report_ref"
+          ],
           "target_property": "report_ref"
         }
       ]

--- a/ui/narrative/methods/insert_set_of_genomes_into_species_tree/display.yaml
+++ b/ui/narrative/methods/insert_set_of_genomes_into_species_tree/display.yaml
@@ -58,7 +58,7 @@ parameters :
         ui-name : |
             Output Genome Set
         short-hint : |
-            A collection of Genome objects.
+            A collection of Genome objects. Note that using an existing genome set will replace the contents of that set with the output of this app.
         placeholder: |
             Name the set of genomes generated
 

--- a/ui/narrative/methods/insert_set_of_genomes_into_species_tree/spec.json
+++ b/ui/narrative/methods/insert_set_of_genomes_into_species_tree/spec.json
@@ -1,78 +1,104 @@
 {
-  "ver" : "1.0.1",
-  "authors" : [ "rsutormin" ],
-  "contact" : "http://kbase.us/contact-us/",
-  "visble" : true,
-  "categories" : ["active","comparative_genomics"],
-  "widgets" : {
-    "input" : null,
-    "output" : "no-display"
+  "ver": "1.0.1",
+  "authors": [
+    "rsutormin"
+  ],
+  "contact": "http://kbase.us/contact-us/",
+  "visble": true,
+  "categories": [
+    "active",
+    "comparative_genomics"
+  ],
+  "widgets": {
+    "input": null,
+    "output": "no-display"
   },
-  "parameters" : [ {
-    "id" : "param0",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : true,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseGenomes.Genome", "KBaseGenomeAnnotations.GenomeAnnotation" ]
-    }
-  }, {
-    "id" : "param1",
-    "optional" : true,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "20" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ ],
-      "validate_as": "int",
-      "min_int" : 1,
-      "max_int" : 200
-    }
-  }, {
-    "id": "copy_genomes",
-    "optional": false,
-    "advanced": false,
-    "allow_multiple": false,
-    "default_values": [
+  "parameters": [
+    {
+      "id": "param0",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": true,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseGenomes.Genome",
+          "KBaseGenomeAnnotations.GenomeAnnotation"
+        ]
+      }
+    },
+    {
+      "id": "param1",
+      "optional": true,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        "20"
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [],
+        "validate_as": "int",
+        "min_int": 1,
+        "max_int": 200
+      }
+    },
+    {
+      "id": "copy_genomes",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
         "0"
-    ],
-    "field_type": "checkbox",
-    "checkbox_options": {
+      ],
+      "field_type": "checkbox",
+      "checkbox_options": {
         "checked_value": 1,
         "unchecked_value": 0
+      }
+    },
+    {
+      "id": "treeID",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseTrees.Tree"
+        ],
+        "is_output_name": true
+      }
+    },
+    {
+      "id": "genomeSetName",
+      "optional": false,
+      "advanced": false,
+      "allow_multiple": false,
+      "default_values": [
+        ""
+      ],
+      "field_type": "text",
+      "text_options": {
+        "valid_ws_types": [
+          "KBaseSearch.GenomeSet"
+        ],
+        "is_output_name": true
+      }
     }
-  }, {
-    "id" : "treeID",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseTrees.Tree" ],
-      "is_output_name":true
-    }
-  }, {
-    "id" : "genomeSetName",
-    "optional" : false,
-    "advanced" : false,
-    "allow_multiple" : false,
-    "default_values" : [ "" ],
-    "field_type" : "text",
-    "text_options" : {
-      "valid_ws_types" : [ "KBaseSearch.GenomeSet" ],
-      "is_output_name":true
-    }
-  } ],
-  "behavior" : {
-    "service-mapping" : {
-      "url" : "",
-      "name" : "SpeciesTreeBuilder",
-      "method" : "construct_species_tree",
-      "input_mapping" : [
+  ],
+  "behavior": {
+    "service-mapping": {
+      "url": "",
+      "name": "SpeciesTreeBuilder",
+      "method": "construct_species_tree",
+      "input_mapping": [
         {
           "input_parameter": "param0",
           "target_property": "new_genomes",
@@ -94,7 +120,7 @@
         {
           "input_parameter": "genomeSetName",
           "target_property": "out_genomeset_ref",
-          "target_type_transform": "ref"
+          "target_type_transform": "putative-ref"
         },
         {
           "narrative_system_variable": "workspace",
@@ -105,17 +131,29 @@
           "target_property": "use_ribosomal_s9_only"
         }
       ],
-      "output_mapping" : [
+      "output_mapping": [
         {
-          "service_method_output_path": [0, "output_result_id"],
+          "service_method_output_path": [
+            0,
+            "output_result_id"
+          ],
           "target_property": "output_result_id"
-        }, {
-          "service_method_output_path": [0, "report_name"],
+        },
+        {
+          "service_method_output_path": [
+            0,
+            "report_name"
+          ],
           "target_property": "report_name"
-        }, {
-          "service_method_output_path": [0, "report_ref"],
+        },
+        {
+          "service_method_output_path": [
+            0,
+            "report_ref"
+          ],
           "target_property": "report_ref"
-        }, {
+        },
+        {
           "narrative_system_variable": "workspace",
           "target_property": "workspaceID"
         }


### PR DESCRIPTION
Fixing species tree builder specs to allow genomeset refs to be either real refs or putative refs, which fixes buggy behaviour where only existing genome sets could be used as output.

This should be fixed properly by editing the code to create a new genomeset each time, instead of requiring an existing genomeset ref, which it then overwrites.